### PR TITLE
ci: add docker build pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# .dockerignore
+Dockerfile
+docker-compose.yml

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+name: build & push docker container
+on:
+  push:
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: metal
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metal.outputs.tags }}
+          labels: ${{ steps.metal.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# build xmage
+# currently fails due to mismatching versions. how did this build ever work?
+
+# FROM maven:3-jdk-8 AS builder
+
+# COPY . .
+# RUN ls -la  \
+#  && mvn clean install -DskipTests \ 
+#  && cd ./Mage.Client \
+#  && ls -la \
+#  && mvn package assembly:single \
+#  && cd ./Mage.Server \
+#  && ls -la \
+#  && mvn package assembly:single \
+#  && ls -la target \
+#  && unzip target/mage-server.zip -d xmage-server
+
+# instead of building, pull from current release
+FROM curlimages/curl AS builder
+
+WORKDIR /tmp
+
+RUN curl https://github.com/magefree/mage/releases/download/xmage_1.4.53V1/mage-full_1.4.53-dev_2024-08-16_15-45.zip -L -o xmage.zip \
+&& ls -la \
+&& unzip -q xmage.zip -d xmage
+
+FROM openjdk:8-jre
+
+ENV XMAGE_DOCKER_SERVER_ADDRESS="0.0.0.0" \
+    XMAGE_DOCKER_PORT="17171" \
+    XMAGE_DOCKER_SEONDARY_BIND_PORT="17179" \
+    XMAGE_DOCKER_MAX_SECONDS_IDLE="600" \
+    XMAGE_DOCKER_AUTHENTICATION_ACTIVATED="false" \
+    XMAGE_DOCKER_SERVER_NAME="mage-server"
+
+EXPOSE 17171 17179
+WORKDIR /xmage
+
+# from being built
+# COPY --from=builder /Utils/xmage-server .
+
+# from release
+COPY --from=builder tmp/xmage/xmage/mage-server /xmage/
+COPY dockerContainerStart.sh /xmage/
+
+RUN chmod +x \
+    /xmage/startServer.sh \
+    /xmage/dockerContainerStart.sh
+
+CMD [ "./dockerContainerStart.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  server:
+    build: .
+    # TODO

--- a/dockerContainerStart.sh
+++ b/dockerContainerStart.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+XMAGE_CONFIG=/xmage/config/config.xml
+
+sed -i -e "s#\(serverAddress=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SERVER_ADDRESS\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(serverName=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SERVER_NAME\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(port=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_PORT\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(secondaryBindPort=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SEONDARY_BIND_PORT\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(maxSecondsIdle=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_MAX_SECONDS_IDLE\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(authenticationActivated=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_AUTHENTICATION_ACTIVATED\"#g" ${XMAGE_CONFIG}
+
+java -Xms256M -Xmx512M -XX:MaxPermSize=256m -Djava.security.policy=./config/security.policy -Djava.util.logging.config.file=./config/logging.config -Dlog4j.configuration=file:./config/log4j.properties -jar ./lib/mage-server-*.jar


### PR DESCRIPTION
This prepares the changes necessary to build official docker images on/for releases. It will fix [#12748](https://github.com/magefree/mage/issues/12748)

I'm keeping this on my fork until I know everything works, then I will retarget to upstream